### PR TITLE
Improve bench configuration

### DIFF
--- a/bench/src/main/scala/newts/bench/NewtypeBench.scala
+++ b/bench/src/main/scala/newts/bench/NewtypeBench.scala
@@ -14,7 +14,7 @@ import org.openjdk.jmh.annotations._
 
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3)
+@Fork(value = 3, jvmArgsAppend = Array("-XX:+UseParallelGC", "-Xms1G", "-Xmx1G"))
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)

--- a/bench/src/main/scala/newts/bench/NewtypeBench.scala
+++ b/bench/src/main/scala/newts/bench/NewtypeBench.scala
@@ -12,6 +12,9 @@ import newts.bench.shapeless.{ConjunctionS, conjunctionSMonoid}
 import newts.{All, Min, ZipList}
 import org.openjdk.jmh.annotations._
 
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)


### PR DESCRIPTION
Reduce default forks and iterations in bench to make the default running time more reasonable. Also, as some of the tests allocate memory, explicitly specify GC configuration to make test runs comparable.