### PR TITLE
Min, Max & Mult instances should be commutative

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,9 @@ cache:
 before_install:
  - export PATH=${PATH}:./vendor/bundle
 install:
-  - rvm use 2.2.3 --install --fuzzy
+  - rvm use 2.2.8 --install --fuzzy
   - gem update --system
   - gem install sass
-  - gem install ruby_dep -v 1.3.1
   - gem install jekyll -v 3.2.1
 after_success:
 - '[[ $TRAVIS_BRANCH == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]] && { sbt +publish ghpagesPushSite; };'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - rvm use 2.2.3 --install --fuzzy
   - gem update --system
   - gem install sass
+  - gem install ruby_dep -v 1.3.1
   - gem install jekyll -v 3.2.1
 after_success:
 - '[[ $TRAVIS_BRANCH == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]] && { sbt +publish ghpagesPushSite; };'

--- a/core/shared/src/main/scala/newts/Max.scala
+++ b/core/shared/src/main/scala/newts/Max.scala
@@ -3,7 +3,7 @@ package newts
 import cats.kernel.{CommutativeMonoid, CommutativeSemigroup, Order}
 import cats.syntax.functor._
 import cats.syntax.order._
-import cats.{Applicative, Eval, Monad, Show, Traverse}
+import cats.{Applicative, Eval, CommutativeMonad, Show, Traverse}
 import newts.internal.MinBounded
 
 import scala.annotation.tailrec
@@ -13,7 +13,7 @@ final case class Max[A](getMax: A) extends AnyVal
 object Max extends MaxInstances0{
   implicit def newtypeInstance[A]: Newtype.Aux[Max[A], A] = Newtype.from[Max[A], A](Max.apply)(_.getMax)
 
-  implicit val monadInstance: Monad[Max] = new Monad[Max] {
+  implicit val monadInstance: CommutativeMonad[Max] = new CommutativeMonad[Max] {
     def pure[A](x: A): Max[A] = Max(x)
     def flatMap[A, B](fa: Max[A])(f: A => Max[B]): Max[B] = f(fa.getMax)
     @tailrec

--- a/core/shared/src/main/scala/newts/Max.scala
+++ b/core/shared/src/main/scala/newts/Max.scala
@@ -1,9 +1,9 @@
 package newts
 
-import cats.kernel.Order
+import cats.kernel.{CommutativeMonoid, CommutativeSemigroup, Order}
 import cats.syntax.functor._
 import cats.syntax.order._
-import cats.{Applicative, Eval, Monad, Monoid, Semigroup, Show, Traverse}
+import cats.{Applicative, Eval, Monad, Show, Traverse}
 import newts.internal.MinBounded
 
 import scala.annotation.tailrec
@@ -23,7 +23,7 @@ object Max extends MaxInstances0{
     }
   }
   
-  implicit def instances[A: Order]: Order[Max[A]] with Semigroup[Max[A]] = new Order[Max[A]] with Semigroup[Max[A]] {
+  implicit def instances[A: Order]: Order[Max[A]] with CommutativeSemigroup[Max[A]] = new Order[Max[A]] with CommutativeSemigroup[Max[A]] {
     def combine(x: Max[A], y: Max[A]): Max[A] = Max(x.getMax max y.getMax)
     def compare(x: Max[A], y: Max[A]): Int = x.getMax compare y.getMax
   }
@@ -34,7 +34,7 @@ object Max extends MaxInstances0{
 }
 
 trait MaxInstances0{
-  implicit def maxMonoid[A](implicit A: MinBounded[A]): Monoid[Max[A]] = new Monoid[Max[A]]{
+  implicit def maxMonoid[A](implicit A: MinBounded[A]): CommutativeMonoid[Max[A]] = new CommutativeMonoid[Max[A]]{
     def empty: Max[A] = Max(A.minValue)
     def combine(x: Max[A], y: Max[A]): Max[A] = Max(x.getMax max y.getMax)
   }

--- a/core/shared/src/main/scala/newts/Min.scala
+++ b/core/shared/src/main/scala/newts/Min.scala
@@ -1,9 +1,9 @@
 package newts
 
-import cats.kernel.Order
+import cats.kernel.{CommutativeMonoid, CommutativeSemigroup, Order}
 import cats.syntax.functor._
 import cats.syntax.order._
-import cats.{Applicative, Eval, Monad, Monoid, Semigroup, Show, Traverse}
+import cats.{Applicative, Eval, Monad, Show, Traverse}
 import newts.internal.MaxBounded
 
 import scala.annotation.tailrec
@@ -23,7 +23,7 @@ object Min extends MinInstances0{
     }
   }
   
-  implicit def instances[A: Order]: Order[Min[A]] with Semigroup[Min[A]] = new Order[Min[A]] with Semigroup[Min[A]] {
+  implicit def instances[A: Order]: Order[Min[A]] with CommutativeSemigroup[Min[A]] = new Order[Min[A]] with CommutativeSemigroup[Min[A]] {
     def combine(x: Min[A], y: Min[A]): Min[A] = Min(x.getMin min y.getMin)
     def compare(x: Min[A], y: Min[A]): Int = x.getMin compare y.getMin
   }
@@ -34,7 +34,7 @@ object Min extends MinInstances0{
 }
 
 trait MinInstances0{
-  implicit def minMonoid[A](implicit A: MaxBounded[A]): Monoid[Min[A]] = new Monoid[Min[A]]{
+  implicit def minMonoid[A](implicit A: MaxBounded[A]): CommutativeMonoid[Min[A]] = new CommutativeMonoid[Min[A]]{
     def empty: Min[A] = Min(MaxBounded[A].maxValue)
     def combine(x: Min[A], y: Min[A]): Min[A] = Min(x.getMin min y.getMin)
   }

--- a/core/shared/src/main/scala/newts/Min.scala
+++ b/core/shared/src/main/scala/newts/Min.scala
@@ -3,7 +3,7 @@ package newts
 import cats.kernel.{CommutativeMonoid, CommutativeSemigroup, Order}
 import cats.syntax.functor._
 import cats.syntax.order._
-import cats.{Applicative, Eval, Monad, Show, Traverse}
+import cats.{Applicative, Eval, CommutativeMonad, Show, Traverse}
 import newts.internal.MaxBounded
 
 import scala.annotation.tailrec
@@ -13,7 +13,7 @@ final case class Min[A](getMin: A) extends AnyVal
 object Min extends MinInstances0{
   implicit def newtypeInstance[A]: Newtype.Aux[Min[A], A] = Newtype.from[Min[A], A](Min.apply)(_.getMin)
 
-  implicit val monadInstance: Monad[Min] = new Monad[Min] {
+  implicit val monadInstance: CommutativeMonad[Min] = new CommutativeMonad[Min] {
     def pure[A](x: A): Min[A] = Min(x)
     def flatMap[A, B](fa: Min[A])(f: A => Min[B]): Min[B] = f(fa.getMin)
     @tailrec

--- a/core/shared/src/main/scala/newts/Mult.scala
+++ b/core/shared/src/main/scala/newts/Mult.scala
@@ -1,8 +1,8 @@
 package newts
 
-import cats.kernel.Eq
+import cats.kernel.{CommutativeMonoid, Eq}
 import cats.syntax.functor._
-import cats.{Applicative, Eval, Monad, Monoid, Show, Traverse}
+import cats.{Applicative, Eval, Monad, Show, Traverse}
 
 import scala.annotation.tailrec
 
@@ -21,7 +21,7 @@ object Mult extends MultInstances0 {
     }
   }
 
-  implicit def monoidInstance[A](implicit num: Numeric[A]): Monoid[Mult[A]] = new Monoid[Mult[A]] {
+  implicit def monoidInstance[A](implicit num: Numeric[A]): CommutativeMonoid[Mult[A]] = new CommutativeMonoid[Mult[A]] {
     val empty: Mult[A] = Mult(num.one)
     def combine(x: Mult[A], y: Mult[A]): Mult[A] = Mult(num.times(x.getMult, y.getMult))
   }

--- a/core/shared/src/main/scala/newts/Mult.scala
+++ b/core/shared/src/main/scala/newts/Mult.scala
@@ -2,7 +2,7 @@ package newts
 
 import cats.kernel.{CommutativeMonoid, Eq}
 import cats.syntax.functor._
-import cats.{Applicative, Eval, Monad, Show, Traverse}
+import cats.{Applicative, Eval, CommutativeMonad, Show, Traverse}
 
 import scala.annotation.tailrec
 
@@ -11,7 +11,7 @@ final case class Mult[A](getMult: A) extends AnyVal
 object Mult extends MultInstances0 {
   implicit def newtypeInstance[A]: Newtype.Aux[Mult[A], A] = Newtype.from[Mult[A], A](Mult.apply)(_.getMult)
 
-  implicit val monadInstance: Monad[Mult] = new Monad[Mult] {
+  implicit val monadInstance: CommutativeMonad[Mult] = new CommutativeMonad[Mult] {
     def pure[A](x: A): Mult[A] = Mult(x)
     def flatMap[A, B](fa: Mult[A])(f: A => Mult[B]): Mult[B] = f(fa.getMult)
     @tailrec

--- a/test/shared/src/test/scala/newts/MaxTest.scala
+++ b/test/shared/src/test/scala/newts/MaxTest.scala
@@ -1,12 +1,12 @@
 package newts
 
-import cats.kernel.laws.discipline.{SemigroupTests, MonoidTests, OrderTests}
+import cats.kernel.laws.discipline.{CommutativeSemigroupTests, CommutativeMonoidTests, OrderTests}
 import cats.laws.discipline.{MonadTests, TraverseTests}
 
 class MaxTest extends NewtsSuite {
 
-  checkAll("Max[Int]", SemigroupTests[Max[Int]].semigroup)
-  checkAll("Max[Int]", MonoidTests[Max[Int]].monoid)
+  checkAll("Max[Int]", CommutativeSemigroupTests[Max[Int]].commutativeSemigroup)
+  checkAll("Max[Int]", CommutativeMonoidTests[Max[Int]].commutativeMonoid)
   checkAll("Max[Int]", OrderTests[Max[Int]].order)
   checkAll("Max[Int]", MonadTests[Max].monad[Int, Int, Int])
   checkAll("Max[Int]", TraverseTests[Max].traverse[Int, Int, Int, Int, Option, Option])

--- a/test/shared/src/test/scala/newts/MaxTest.scala
+++ b/test/shared/src/test/scala/newts/MaxTest.scala
@@ -1,14 +1,14 @@
 package newts
 
 import cats.kernel.laws.discipline.{CommutativeSemigroupTests, CommutativeMonoidTests, OrderTests}
-import cats.laws.discipline.{MonadTests, TraverseTests}
+import cats.laws.discipline.{CommutativeMonadTests, TraverseTests}
 
 class MaxTest extends NewtsSuite {
 
   checkAll("Max[Int]", CommutativeSemigroupTests[Max[Int]].commutativeSemigroup)
   checkAll("Max[Int]", CommutativeMonoidTests[Max[Int]].commutativeMonoid)
   checkAll("Max[Int]", OrderTests[Max[Int]].order)
-  checkAll("Max[Int]", MonadTests[Max].monad[Int, Int, Int])
+  checkAll("Max[Int]", CommutativeMonadTests[Max].commutativeMonad[Int, Int, Int])
   checkAll("Max[Int]", TraverseTests[Max].traverse[Int, Int, Int, Int, Option, Option])
 
   test("combine"){

--- a/test/shared/src/test/scala/newts/MinTest.scala
+++ b/test/shared/src/test/scala/newts/MinTest.scala
@@ -1,14 +1,14 @@
 package newts
 
 import cats.kernel.laws.discipline.{CommutativeSemigroupTests, CommutativeMonoidTests, OrderTests}
-import cats.laws.discipline.{MonadTests, TraverseTests}
+import cats.laws.discipline.{CommutativeMonadTests, TraverseTests}
 
 class MinTest extends NewtsSuite {
 
   checkAll("Min[Int]", CommutativeSemigroupTests[Min[Int]].commutativeSemigroup)
   checkAll("Min[Int]", CommutativeMonoidTests[Min[Int]].commutativeMonoid)
   checkAll("Min[Int]", OrderTests[Min[Int]].order)
-  checkAll("Min[Int]", MonadTests[Dual].monad[Int, Int, Int])
+  checkAll("Min[Int]", CommutativeMonadTests[Min].commutativeMonad[Int, Int, Int])
   checkAll("Min[Int]", TraverseTests[Min].traverse[Int, Int, Int, Int, Option, Option])
 
   test("combine"){

--- a/test/shared/src/test/scala/newts/MinTest.scala
+++ b/test/shared/src/test/scala/newts/MinTest.scala
@@ -1,12 +1,12 @@
 package newts
 
-import cats.kernel.laws.discipline.{SemigroupTests, MonoidTests, OrderTests}
+import cats.kernel.laws.discipline.{CommutativeSemigroupTests, CommutativeMonoidTests, OrderTests}
 import cats.laws.discipline.{MonadTests, TraverseTests}
 
 class MinTest extends NewtsSuite {
 
-  checkAll("Min[Int]", SemigroupTests[Min[Int]].semigroup)
-  checkAll("Min[Int]", MonoidTests[Min[Int]].monoid)
+  checkAll("Min[Int]", CommutativeSemigroupTests[Min[Int]].commutativeSemigroup)
+  checkAll("Min[Int]", CommutativeMonoidTests[Min[Int]].commutativeMonoid)
   checkAll("Min[Int]", OrderTests[Min[Int]].order)
   checkAll("Min[Int]", MonadTests[Dual].monad[Int, Int, Int])
   checkAll("Min[Int]", TraverseTests[Min].traverse[Int, Int, Int, Int, Option, Option])

--- a/test/shared/src/test/scala/newts/MultTest.scala
+++ b/test/shared/src/test/scala/newts/MultTest.scala
@@ -1,13 +1,13 @@
 package newts
 
 import cats.kernel.laws.discipline.{CommutativeMonoidTests, EqTests}
-import cats.laws.discipline.{MonadTests, TraverseTests}
+import cats.laws.discipline.{CommutativeMonadTests, TraverseTests}
 
 class MultTest extends NewtsSuite {
 
   checkAll("Mult[Int]", CommutativeMonoidTests[Mult[Int]].commutativeMonoid)
   checkAll("Mult[Int]", EqTests[Mult[Int]].eqv)
-  checkAll("Mult[Int]", MonadTests[Mult].monad[Int, Int, Int])
+  checkAll("Mult[Int]", CommutativeMonadTests[Mult].commutativeMonad[Int, Int, Int])
   checkAll("Mult[Int]", TraverseTests[Mult].traverse[Int, Int, Int, Int, Option, Option])
 
   test("combine") {

--- a/test/shared/src/test/scala/newts/MultTest.scala
+++ b/test/shared/src/test/scala/newts/MultTest.scala
@@ -1,11 +1,11 @@
 package newts
 
-import cats.kernel.laws.discipline.{MonoidTests, EqTests}
+import cats.kernel.laws.discipline.{CommutativeMonoidTests, EqTests}
 import cats.laws.discipline.{MonadTests, TraverseTests}
 
 class MultTest extends NewtsSuite {
 
-  checkAll("Mult[Int]", MonoidTests[Mult[Int]].monoid)
+  checkAll("Mult[Int]", CommutativeMonoidTests[Mult[Int]].commutativeMonoid)
   checkAll("Mult[Int]", EqTests[Mult[Int]].eqv)
   checkAll("Mult[Int]", MonadTests[Mult].monad[Int, Int, Int])
   checkAll("Mult[Int]", TraverseTests[Mult].traverse[Int, Int, Int, Int, Option, Option])


### PR DESCRIPTION
This PR makes the `Semigroup`, `Monoid` and `Monad` instances for `Min`, `Max` and `Mult` commutative so they can be used in scenarios in which commutativity is a requirement.